### PR TITLE
Add check_connections(timeout) method to ctrk utils

### DIFF
--- a/src/crtk/utils.py
+++ b/src/crtk/utils.py
@@ -156,7 +156,7 @@ class utils:
             if len(unconnected) == 0:
                 break
 
-            rospy.sleep(0.2)
+            rospy.sleep(0.01)
 
         # last check of connection status, raise error if any remain unconnected
         unconnected_publishers = [p for p in self.__publishers if not connected(p)]


### PR DESCRIPTION
check_connections() will check that all publishers and subscribers have at least one connection. It waits at most timeout seconds, raising a TimeoutError if some connections have not established within the timeout period. check_connections() will return early as soon as all publishers/subscribes have at least one connection.

https://github.com/jhu-dvrk/dvrk-ros/pull/42