### PR TITLE
Update wait_move_handle to wait for transition.

### DIFF
--- a/src/crtk/wait_move_handle.py
+++ b/src/crtk/wait_move_handle.py
@@ -11,9 +11,9 @@
 #       for is_busy=True followed by is_busy=False
 class wait_move_handle:
     def __init__(self, class_instance, ral):
-        self.inst = class_instance
-        self.ral = ral
-        self.start_time = ral.now()
+        self.__inst = class_instance
+        self.__ral = ral
+        self.__start_time = ral.now()
 
         if not class_instance:
             self.wait = self._unsupported
@@ -23,16 +23,16 @@ class wait_move_handle:
         raise RuntimeWarning("can't wait, class doesn't support CRTK operating state")
 
     def wait(self, is_busy = False, timeout = 30.0):
-        if self.ral.is_shutdown():
+        if self.__ral.is_shutdown():
             return False
 
-        return self.inst.wait_for_busy(is_busy = is_busy,
-                                       start_time = self.start_time,
+        return self.__inst.wait_for_busy(is_busy = is_busy,
+                                       start_time = self.__start_time,
                                        timeout = timeout)
 
     def is_busy(self, timeout = 30.0):
         # if we keep asking past timeout, throw an exception
-        if (self.ral.now() - self.start_time) > self.ral.create_duration(timeout):
+        if (self.__ral.now() - self.__start_time) > self.__ral.create_duration(timeout):
             raise RuntimeWarning('is_busy() called after timeout')
 
-        return self.inst.is_busy(start_time = self.start_time)
+        return self.__inst.is_busy(start_time = self.__start_time)

--- a/src/crtk/wait_move_handle.py
+++ b/src/crtk/wait_move_handle.py
@@ -4,28 +4,35 @@
 # Copyright (c) 2020-2021 Johns Hopkins University, University of Washington, Worcester Polytechnic Institute
 # Released under MIT License
 
+# Given a class with CRTK operating state, waits for busy/not busy conditions
+#
+# - wait(is_busy=True) waits for a new is_busy=True operating state to arrive
+# - wait(is_busy=False) waits for *transition* to is_busy=False, i.e. waits
+#       for is_busy=True followed by is_busy=False
 class wait_move_handle:
     def __init__(self, class_instance, ral):
-        self.__class_instance = class_instance
-        self.__ral = ral
-        self.__start_time = ral.now()
+        self.inst = class_instance
+        self.ral = ral
+        self.start_time = ral.now()
+
+        if not class_instance:
+            self.wait = self._unsupported
+            self.is_busy = self._unsupported
+
+    def _unsupported(self, *args, **kwargs):
+        raise RuntimeWarning("can't wait, class doesn't support CRTK operating state")
 
     def wait(self, is_busy = False, timeout = 30.0):
-        if self.__ral.is_shutdown():
+        if self.ral.is_shutdown():
             return False
-        if self.__class_instance:
-            return self.__class_instance.wait_for_busy(is_busy = is_busy,
-                                                       start_time = self.__start_time,
-                                                       timeout = timeout)
-        else:
-            raise RuntimeWarning('can\'t wait, the class doesn\'t support CRTK operating state')
+
+        return self.inst.wait_for_busy(is_busy = is_busy,
+                                       start_time = self.start_time,
+                                       timeout = timeout)
 
     def is_busy(self, timeout = 30.0):
         # if we keep asking past timeout, throw an exception
-        if (self.__ral.now() - self.__start_time) > self.__ral.create_duration(timeout):
-            raise RuntimeWarning('is_busy past timeout')
-        # else, check if we have a new state after start time and return is_busy
-        if self.__class_instance:
-            return self.__class_instance.is_busy(start_time = self.__start_time)
-        else:
-            raise RuntimeWarning('can\'t wait, the class doesn\'t support CRTK operating state')
+        if (self.ral.now() - self.start_time) > self.ral.create_duration(timeout):
+            raise RuntimeWarning('is_busy() called after timeout')
+
+        return self.inst.is_busy(start_time = self.start_time)


### PR DESCRIPTION
When waiting for robot idle, e.g. waiting for move command to finish, the wait handle will move wait for a transition from busy to idle, rather than just for idle status.

Waiting for the robot to become busy (e.g. waiting for a move to start) should work as before. That is, it will just wait for new is_busy=True operating state, *not* an idle-to-busy transition.

I've run a bunch of the crtk/dvrk test scripts, but this should at least also be tested on the Galen.